### PR TITLE
feat: improve FB2 reader rendering (#242)

### DIFF
--- a/app/src/main/java/ua/acclorite/book_story/data/parser/document/DocumentParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/document/DocumentParser.kt
@@ -9,6 +9,7 @@ package ua.acclorite.book_story.data.parser.document
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.text.AnnotatedString
 import kotlinx.coroutines.yield
 import org.jsoup.nodes.Document
 import ua.acclorite.book_story.core.helpers.clearAllMarkdown
@@ -21,6 +22,9 @@ import java.nio.charset.StandardCharsets
 import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
 import javax.inject.Inject
+
+/** Marker standing in for FB2 <empty-line/>, resolved to a blank line. */
+const val EMPTY_LINE_MARKER = "[[[emptyline]]]"
 
 class DocumentParser @Inject constructor(
     private val markdownParser: MarkdownParser
@@ -133,6 +137,13 @@ class DocumentParser @Inject constructor(
 
                 if (line.containsVisibleText()) {
                     when {
+                        // Empty line marker (from FB2 <empty-line/>). A blank line
+                        // cannot survive the containsVisibleText() gate on its own,
+                        // so it is carried as a marker and rendered as a blank line.
+                        line.trim() == EMPTY_LINE_MARKER -> {
+                            readerText.add(ReaderText.Text(AnnotatedString(" ")))
+                        }
+
                         // Chapter marker (from FB2 <title>), checked before
                         // imageRegex as the latter also matches this line
                         chapterRegex.matches(line) -> {

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/document/DocumentParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/document/DocumentParser.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.text.AnnotatedString
 import kotlinx.coroutines.yield
 import org.jsoup.nodes.Document
+import org.jsoup.nodes.TextNode
 import ua.acclorite.book_story.core.helpers.clearAllMarkdown
 import ua.acclorite.book_story.core.helpers.clearMarkdown
 import ua.acclorite.book_story.core.helpers.containsVisibleText
@@ -61,8 +62,14 @@ class DocumentParser @Inject constructor(
                     element.html(element.html().replace(Regex("\\n+"), ""))
                 }
 
-                // Remove <head>'s title
-                select("title").remove()
+                // Section/body titles are already turned into chapter markers
+                // upstream; the titles left here belong to FB2 <poem>/<epigraph>/
+                // <cite>. Flatten them into a bold line instead of dropping them.
+                select("title").forEach { title ->
+                    val text = title.wholeText().replace(Regex("\\s+"), " ").trim()
+                    if (text.isBlank()) title.remove()
+                    else title.replaceWith(TextNode("\n**$text**\n"))
+                }
 
                 // Markdown
                 select("hr").append("\n---\n")
@@ -72,6 +79,34 @@ class DocumentParser @Inject constructor(
                 select("h3").append("**").prepend("**")
                 select("strong").append("**").prepend("**")
                 select("em").append("_").prepend("_")
+
+                // FB2 inline: <emphasis> is the italic tag (FB2 has no <em>)
+                select("emphasis").append("_").prepend("_")
+
+                // FB2 block-level tags carry no line break of their own, so in
+                // files without pretty-printing they glue to surrounding text.
+                select("subtitle").prepend("\n_**").append("**_\n") // bold + italic
+                select("poem").prepend("\n").append("\n")
+                select("epigraph").prepend("\n").append("\n")
+                // Blank line between stanzas, but not after the last one
+                select("stanza").forEach { stanza ->
+                    if (stanza.nextElementSibling()?.tagName() == "stanza") {
+                        stanza.append("\n$EMPTY_LINE_MARKER\n")
+                    } else {
+                        stanza.append("\n")
+                    }
+                }
+                select("v").append("\n") // verse line
+                select("text-author").prepend("\n_").append("_\n")
+
+                // FB2 <epigraph>/<cite> are conventionally set in italic. The "\n"
+                // that the loop above appended to each <p> is its last child, so the
+                // closing underscore is inserted just before it, not after.
+                select("epigraph > p, cite > p").forEach { paragraph ->
+                    paragraph.prepend("_")
+                    paragraph.childNode(paragraph.childNodeSize() - 1)
+                        .before(TextNode("_"))
+                }
                 select("a").forEach { element ->
                     var link = element.attr("href")
                     if (!link.startsWith("http") || element.wholeText().isBlank()) return@forEach

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/document/DocumentParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/document/DocumentParser.kt
@@ -34,6 +34,20 @@ const val EMPTY_LINE_MARKER = "[[[emptyline]]]"
  */
 const val STRIKETHROUGH_MARK = "\uE011"
 
+private val SUBSCRIPTS = mapOf(
+    '0' to '₀', '1' to '₁', '2' to '₂', '3' to '₃', '4' to '₄', '5' to '₅',
+    '6' to '₆', '7' to '₇', '8' to '₈', '9' to '₉',
+    '+' to '₊', '-' to '₋', '=' to '₌', '(' to '₍', ')' to '₎'
+)
+private val SUPERSCRIPTS = mapOf(
+    '0' to '⁰', '1' to '¹', '2' to '²', '3' to '³', '4' to '⁴', '5' to '⁵',
+    '6' to '⁶', '7' to '⁷', '8' to '⁸', '9' to '⁹',
+    '+' to '⁺', '-' to '⁻', '=' to '⁼', '(' to '⁽', ')' to '⁾'
+)
+
+private fun String.mapChars(mapping: Map<Char, Char>): String =
+    map { mapping[it] ?: it }.joinToString("")
+
 class DocumentParser @Inject constructor(
     private val markdownParser: MarkdownParser
 ) {
@@ -119,6 +133,14 @@ class DocumentParser @Inject constructor(
                 select("code").prepend("`").append("`")
                 // <strikethrough> wrapped in a sentinel, styled by MarkdownParser
                 select("strikethrough").prepend(STRIKETHROUGH_MARK).append(STRIKETHROUGH_MARK)
+                // <sub>/<sup> mapped to Unicode sub/superscript characters.
+                // Covers digits and signs, which is what FB2 uses them for.
+                select("sub").forEach { element ->
+                    element.text(element.text().mapChars(SUBSCRIPTS))
+                }
+                select("sup").forEach { element ->
+                    element.text(element.text().mapChars(SUPERSCRIPTS))
+                }
                 select("a").forEach { element ->
                     var link = element.attr("href")
                     if (!link.startsWith("http") || element.wholeText().isBlank()) return@forEach

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/document/DocumentParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/document/DocumentParser.kt
@@ -27,6 +27,13 @@ import javax.inject.Inject
 /** Marker standing in for FB2 <empty-line/>, resolved to a blank line. */
 const val EMPTY_LINE_MARKER = "[[[emptyline]]]"
 
+/**
+ * Private-use sentinel wrapping FB2 <strikethrough> content. [MarkdownParser]
+ * turns the enclosed text into a real strike-through span, which — unlike a
+ * combining overlay — is font independent.
+ */
+const val STRIKETHROUGH_MARK = "\uE011"
+
 class DocumentParser @Inject constructor(
     private val markdownParser: MarkdownParser
 ) {
@@ -107,6 +114,11 @@ class DocumentParser @Inject constructor(
                     paragraph.childNode(paragraph.childNodeSize() - 1)
                         .before(TextNode("_"))
                 }
+
+                // FB2 inline: <code> as a monospace backtick code span
+                select("code").prepend("`").append("`")
+                // <strikethrough> wrapped in a sentinel, styled by MarkdownParser
+                select("strikethrough").prepend(STRIKETHROUGH_MARK).append(STRIKETHROUGH_MARK)
                 select("a").forEach { element ->
                     var link = element.attr("href")
                     if (!link.startsWith("http") || element.wholeText().isBlank()) return@forEach

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/document/DocumentParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/document/DocumentParser.kt
@@ -129,9 +129,28 @@ class DocumentParser @Inject constructor(
                 ).trim()
 
                 val imageRegex = Regex("""\[\[(.*?)\|(.*?)]]""")
+                val chapterRegex = Regex("""\[\[\[chapter\|([01])\|(.*)]]]""")
 
                 if (line.containsVisibleText()) {
                     when {
+                        // Chapter marker (from FB2 <title>), checked before
+                        // imageRegex as the latter also matches this line
+                        chapterRegex.matches(line) -> {
+                            if (!includeChapter) return@forEach
+
+                            val match = chapterRegex.matchEntire(line) ?: return@forEach
+                            val title = match.groupValues[2].clearAllMarkdown().trim()
+                            if (!title.containsVisibleText()) return@forEach
+
+                            readerText.add(
+                                ReaderText.Chapter(
+                                    title = title,
+                                    nested = match.groupValues[1] == "1"
+                                )
+                            )
+                            chapterAdded = true
+                        }
+
                         imageRegex.matches(line) -> {
                             val trimmedLine = line.removeSurrounding("[[", "]]")
                             val src = trimmedLine.substringBefore("|")

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/document/MarkdownParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/document/MarkdownParser.kt
@@ -11,11 +11,13 @@ import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.text.withStyle
+import org.commonmark.node.Code
 import org.commonmark.node.Emphasis
 import org.commonmark.node.Heading
 import org.commonmark.node.Link
@@ -66,6 +68,12 @@ class MarkdownParser @Inject constructor(
                 }
             }
 
+            is Code -> {
+                withStyle(SpanStyle(fontFamily = FontFamily.Monospace)) {
+                    append(node.literal)
+                }
+            }
+
             is Link -> {
                 withLink(
                     LinkAnnotation.Url(
@@ -79,12 +87,36 @@ class MarkdownParser @Inject constructor(
             }
 
             is Text -> {
-                append(node.literal.clearMarkdown())
+                appendStrikethrough(node.literal.clearMarkdown())
                 parseChildren(node)
             }
 
             else -> {
                 parseChildren(node)
+            }
+        }
+    }
+
+    /**
+     * Appends [text], turning any run wrapped in [STRIKETHROUGH_MARK] into a
+     * strike-through span. Each mark toggles the state, so the closing style
+     * composes with whatever emphasis the surrounding nodes already applied.
+     */
+    private fun AnnotatedString.Builder.appendStrikethrough(text: String) {
+        if (!text.contains(STRIKETHROUGH_MARK)) {
+            append(text)
+            return
+        }
+        var struck = false
+        text.split(STRIKETHROUGH_MARK).forEachIndexed { index, segment ->
+            if (index > 0) struck = !struck
+            if (segment.isEmpty()) return@forEachIndexed
+            if (struck) {
+                withStyle(SpanStyle(textDecoration = TextDecoration.LineThrough)) {
+                    append(segment)
+                }
+            } else {
+                append(segment)
             }
         }
     }

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/text/XmlTextParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/text/XmlTextParser.kt
@@ -8,6 +8,7 @@ package ua.acclorite.book_story.data.parser.text
 
 import kotlinx.coroutines.yield
 import org.jsoup.Jsoup
+import org.jsoup.nodes.TextNode
 import org.jsoup.parser.Parser
 import ua.acclorite.book_story.core.log.logE
 import ua.acclorite.book_story.core.log.logI
@@ -27,7 +28,29 @@ class XmlTextParser @Inject constructor(
 
         return try {
             val readerText = cachedFile.openInputStream()?.use { stream ->
-                documentParser.parseDocument(Jsoup.parse(stream, null, "", Parser.xmlParser()))
+                val document = Jsoup.parse(stream, null, "", Parser.xmlParser())
+
+                // FB2 keeps chapter headings in <title> of <body>/<section>.
+                // Convert them to chapter markers before [DocumentParser]
+                // removes all <title> elements.
+                document.selectFirst("body")?.select("title")?.forEach { title ->
+                    val parentTag = title.parent()?.tagName()
+                    if (parentTag != "body" && parentTag != "section") return@forEach
+
+                    val text = title.wholeText()
+                        .replace(Regex("\\s+"), " ")
+                        .trim()
+                    if (text.isBlank()) return@forEach
+
+                    val nested = title.parents().count { parent ->
+                        parent.tagName() == "section"
+                    } > 1
+                    title.replaceWith(
+                        TextNode("\n[[[chapter|${if (nested) 1 else 0}|$text]]]\n")
+                    )
+                }
+
+                documentParser.parseDocument(document)
             }
 
             yield()

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/text/XmlTextParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/text/XmlTextParser.kt
@@ -14,6 +14,7 @@ import ua.acclorite.book_story.core.log.logE
 import ua.acclorite.book_story.core.log.logI
 import ua.acclorite.book_story.data.model.file.CachedFile
 import ua.acclorite.book_story.data.parser.document.DocumentParser
+import ua.acclorite.book_story.data.parser.document.EMPTY_LINE_MARKER
 import ua.acclorite.book_story.domain.model.reader.ReaderText
 import javax.inject.Inject
 
@@ -48,6 +49,13 @@ class XmlTextParser @Inject constructor(
                     title.replaceWith(
                         TextNode("\n[[[chapter|${if (nested) 1 else 0}|$text]]]\n")
                     )
+                }
+
+                // FB2 <empty-line/> is a blank paragraph. It carries no text, so
+                // it is turned into a marker that survives text extraction and is
+                // resolved back to a blank line by [DocumentParser].
+                document.select("empty-line").forEach { emptyLine ->
+                    emptyLine.replaceWith(TextNode("\n$EMPTY_LINE_MARKER\n"))
                 }
 
                 documentParser.parseDocument(document)


### PR DESCRIPTION
Improves how FB2 books are rendered in the reader. FB2 markup was mostly
passed through as plain text, so formatting was lost and, in files without
pretty-printing, blocks glued to the surrounding text. Blank lines
disappeared entirely (#242).

All changes live in the shared `DocumentParser`/`MarkdownParser`, so the
inline styling below (`<code>`, strikethrough, sub/superscript) improves
EPUB/HTML rendering too; the block/FB2-only tags are no-ops there.

### Chapters

- FB2 chapter headings (`<title>` of `<body>`/`<section>`) become chapter
  markers, so the reader's table of contents is populated. Nested sections
  are marked as nested.

### Empty lines (#242)

- `<empty-line/>` carries no text and never survived text extraction, so the
  blank line was lost. It is now turned into a marker and resolved back to a
  blank line when building the reader text.

### Block formatting

- `<emphasis>` rendered as italic (FB2 has no `<em>`).
- `<subtitle>` as a bold italic line.
- `<poem>`/`<stanza>`/`<v>` broken into lines so verses no longer merge,
  with a blank line between stanzas.
- `<epigraph>`/`<cite>` paragraphs in italic, `<text-author>` on its own line.
- `<poem>`/`<epigraph>`/`<cite>` titles flattened to a bold line instead of
  being dropped.

### Inline styling

- `<code>` as a monospace code span.
- `<strikethrough>` as a real strike-through span (font independent, single
  continuous line).
- `<sub>`/`<sup>` mapped to Unicode sub/superscript characters (digits and
  arithmetic signs — chemical formulas, exponents, footnote markers).

### Scope

This addresses the rendering half of #242. Tables, footnote bodies
(`<body name="notes">`) and spaced-out separators (`* * *`) are out of scope
here; the separator fix is a separate PR against master.

### Testing

Verified on device with a hand-written FB2 that exercises each tag, plus real
books. Each transformation was also checked against the actual jsoup output
offline.
