### PR TITLE
fix: section separators and tabs in parsed text

### DIFF
--- a/app/src/main/java/ua/acclorite/book_story/data/parser/document/DocumentParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/document/DocumentParser.kt
@@ -121,6 +121,9 @@ class DocumentParser @Inject constructor(
                 yield()
 
                 val formattedLine = line.replace(
+                    // Tabs are not rendered and would glue the surrounding words together
+                    "\t", " "
+                ).replace(
                     Regex("""\*\*\*\s*(.*?)\s*\*\*\*"""), "_**$1**_"
                 ).replace(
                     Regex("""\*\*\s*(.*?)\s*\*\*"""), "**$1**"

--- a/app/src/main/java/ua/acclorite/book_story/data/parser/document/DocumentParser.kt
+++ b/app/src/main/java/ua/acclorite/book_story/data/parser/document/DocumentParser.kt
@@ -129,6 +129,8 @@ class DocumentParser @Inject constructor(
                 ).trim()
 
                 val imageRegex = Regex("""\[\[(.*?)\|(.*?)]]""")
+                // Section separator: "---", "***", "___", also spaced out ("* * *")
+                val separatorRegex = Regex("""^([-*_])(\s*\1){2,}$""")
 
                 if (line.containsVisibleText()) {
                     when {
@@ -161,7 +163,9 @@ class DocumentParser @Inject constructor(
                             )
                         }
 
-                        line == "---" || line == "***" -> readerText.add(ReaderText.Separator)
+                        separatorRegex.matches(formattedLine) -> {
+                            readerText.add(ReaderText.Separator)
+                        }
 
                         else -> {
                             if (


### PR DESCRIPTION
Two small parser fixes, both visible in any format that goes through `DocumentParser` (EPUB, HTML, FB2).

### 1. Section separators were never recognized

`ReaderText.Separator` was produced by an exact comparison against the raw line:

```kotlin
line == "---" || line == "***" -> readerText.add(ReaderText.Separator)
```

The line still carries the indentation of the source document, so in any pretty-printed file the comparison fails. What the reader shows instead:

- `---` falls through to the text branch and is rendered as literal dashes
- `***` is stripped by `clearMarkdown()` and the line disappears completely

Now the trimmed line is matched with a regex, which additionally covers the spaced-out (`* * *`) and underscore (`___`) forms that authors commonly use for a scene break. Silently dropped `* * *` lines are a real-world problem — see #242.

### 2. Tabs glue words together

A tab inside a paragraph is laid out with zero width, so `word\tword` renders as `wordword`. Tabs are now replaced with a space.

### Note on behaviour change

A `---` line that previously rendered as three literal dashes now renders as an actual separator. That is the intended behaviour, but it is a visible change for existing EPUB/HTML books, so calling it out explicitly.

### Testing

Verified on device with a hand-written FB2 covering `***`, `* * *`, `* * * * *`, `---` and a tab inside a paragraph. Before: only a literal `---` line was visible, the rest disappeared. After: four separators are drawn and the tabbed words are spaced correctly.

The separator regex was checked against non-separator lines as well — `**bold**`, `_italic_`, `* list item`, `Chapter - 1`, a lone `-` and `--` are left untouched.
